### PR TITLE
Event sticky formatting

### DIFF
--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -73,10 +73,20 @@ module.exports = {
         }
 
         let resultEventString = "";
-        eventsArray.forEach((event) => {
+
+        for (let category of categories) {
+            resultEventString += `**${category.name}**\n`;
+            
+            for (let event of category.events) {
+                resultEventString += `**\`${event.date.getDate()}.${event.date.getMonth() + 1}.${event.date.getFullYear()}\`** ${event.content}\n`;
+            }
+        }
+
+
+        /* eventsArray.forEach((event) => {
             if (event.date.getTime() < new Date().getTime()) { return; } // If the event is expired, return
             resultEventString += `**\`${event.date.getDate()}.${event.date.getMonth() + 1}.${event.date.getFullYear()}\`** ${event.content} \n`;
-        });
+        }); */
 
         return {
             "embed": {

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -90,7 +90,7 @@ module.exports = {
             resultEventString += `**${category.name}**\n`;
             
             for (let event of category.events) {
-                resultEventString += `**\`${event.date.getDate()}.${event.date.getMonth() + 1}.${event.date.getFullYear()}\`** ${event.content}\n`;
+                resultEventString += `**\` ${event.date.getDate()}.${event.date.getMonth() + 1}.${event.date.getFullYear()} (${this.calculateRemainingDays(event.date)}d) \`** ${event.content}\n`;
             }
 
             resultEventString += "\n";
@@ -112,5 +112,14 @@ module.exports = {
                 "footer": CONFIG.EMBED.FOOTER()
             }
         };
+    },
+
+    calculateRemainingDays: function(eventDate) {
+        let eventTs = eventDate.getTime();
+        let currentTs = new Date().getTime();
+
+        let deltaTs = eventTs - currentTs;
+
+        return Math.floor((deltaTs / (24*60*60*1000))*100) / 100;
     }
 };

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -1,6 +1,33 @@
 const CONFIG = require("../../modules/config");
 const dbInt = require("../../db/interface");
 
+const categories = [
+    {
+        name: "In the next 24 hours",
+        maxDelta: 24*60*60*1000
+    },
+    {
+        name: "In the next 48 hours",
+        maxDelta: 48*60*60*1000
+    },
+    {
+        name: "In the next week",
+        maxDelta: 7*24*60*60*1000
+    },
+    {
+        name: "In the next month",
+        maxDelta: 30*24*60*60*1000
+    },
+    {
+        name: "In the next year",
+        maxDelta: 365.25*24*60*60*1000
+    },
+    {
+        name: "Other",
+        maxDelta: Infinity
+    },
+];
+
 module.exports = {
     generator: async function (generatorData) {
         let guildId = generatorData.guildId;

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -28,27 +28,37 @@ module.exports = {
         //* CATEGORIES
         let categories = [
             {
-                name: "24 hours",
+                name: "Less than a day",
                 maxDelta: 24*60*60*1000,
                 events: []
             },
             {
-                name: "48 hours",
+                name: "Less than 2 days",
                 maxDelta: 48*60*60*1000,
                 events: []
             },
             {
-                name: "Week",
+                name: "Less than a week",
                 maxDelta: 7*24*60*60*1000,
                 events: []
             },
             {
-                name: "Month",
+                name: "Less than a month",
                 maxDelta: 30*24*60*60*1000,
                 events: []
             },
             {
-                name: "Year",
+                name: "Less than 2 months",
+                maxDelta: 60*24*60*60*1000,
+                events: []
+            },
+            {
+                name: "Less than 3 months",
+                maxDelta: 90*24*60*60*1000,
+                events: []
+            },
+            {
+                name: "Less than a year",
                 maxDelta: 365.25*24*60*60*1000,
                 events: []
             },

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -28,27 +28,27 @@ module.exports = {
         //* CATEGORIES
         let categories = [
             {
-                name: "In the next 24 hours",
+                name: "24 hours",
                 maxDelta: 24*60*60*1000,
                 events: []
             },
             {
-                name: "In the next 48 hours",
+                name: "48 hours",
                 maxDelta: 48*60*60*1000,
                 events: []
             },
             {
-                name: "In the next week",
+                name: "Week",
                 maxDelta: 7*24*60*60*1000,
                 events: []
             },
             {
-                name: "In the next month",
+                name: "Month",
                 maxDelta: 30*24*60*60*1000,
                 events: []
             },
             {
-                name: "In the next year",
+                name: "Year",
                 maxDelta: 365.25*24*60*60*1000,
                 events: []
             },
@@ -82,6 +82,8 @@ module.exports = {
             for (let event of category.events) {
                 resultEventString += `**\`${event.date.getDate()}.${event.date.getMonth() + 1}.${event.date.getFullYear()}\`** ${event.content}\n`;
             }
+
+            resultEventString += "\n";
         }
 
 

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -75,6 +75,8 @@ module.exports = {
         let resultEventString = "";
 
         for (let category of categories) {
+            if (category.events.length < 1) { continue; } // We don't want to output categories which have no events in them
+
             resultEventString += `**${category.name}**\n`;
             
             for (let event of category.events) {

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -22,6 +22,8 @@ module.exports = {
             eventsArray = [];
         }
 
+        eventsArray.sort(function(a, b){return a.date.getTime() - b.date.getTime();});
+
         let resultEventString = "";
         eventsArray.forEach((event) => {
             if (event.date.getTime() < new Date().getTime()) { return; } // If the event is expired, return

--- a/sticky/generators/events.js
+++ b/sticky/generators/events.js
@@ -1,33 +1,6 @@
 const CONFIG = require("../../modules/config");
 const dbInt = require("../../db/interface");
 
-const categories = [
-    {
-        name: "In the next 24 hours",
-        maxDelta: 24*60*60*1000
-    },
-    {
-        name: "In the next 48 hours",
-        maxDelta: 48*60*60*1000
-    },
-    {
-        name: "In the next week",
-        maxDelta: 7*24*60*60*1000
-    },
-    {
-        name: "In the next month",
-        maxDelta: 30*24*60*60*1000
-    },
-    {
-        name: "In the next year",
-        maxDelta: 365.25*24*60*60*1000
-    },
-    {
-        name: "Other",
-        maxDelta: Infinity
-    },
-];
-
 module.exports = {
     generator: async function (generatorData) {
         let guildId = generatorData.guildId;
@@ -50,6 +23,54 @@ module.exports = {
         }
 
         eventsArray.sort(function(a, b){return a.date.getTime() - b.date.getTime();});
+        
+
+        //* CATEGORIES
+        let categories = [
+            {
+                name: "In the next 24 hours",
+                maxDelta: 24*60*60*1000,
+                events: []
+            },
+            {
+                name: "In the next 48 hours",
+                maxDelta: 48*60*60*1000,
+                events: []
+            },
+            {
+                name: "In the next week",
+                maxDelta: 7*24*60*60*1000,
+                events: []
+            },
+            {
+                name: "In the next month",
+                maxDelta: 30*24*60*60*1000,
+                events: []
+            },
+            {
+                name: "In the next year",
+                maxDelta: 365.25*24*60*60*1000,
+                events: []
+            },
+            {
+                name: "Other",
+                maxDelta: Infinity,
+                events: []
+            },
+        ];
+
+        const currentTime = new Date().getTime();
+
+        for (let event of eventsArray) {
+            if (event.date.getTime() < new Date().getTime()) { continue; } // If the event is expired, move on
+
+            for(let category of categories) {
+                if (event.date.getTime() < currentTime + category.maxDelta) {
+                    category.events.push(event);
+                    break;
+                }
+            }
+        }
 
         let resultEventString = "";
         eventsArray.forEach((event) => {

--- a/sticky/stickyController.js
+++ b/sticky/stickyController.js
@@ -116,6 +116,10 @@ module.exports = {
             } else {
                 let channel = dClient.channels.get(doc.c_id);
 
+                if (!channel) { // If the channel is out of reach of tea-bot
+                    continue; // Rather that deleting sticky doc, just continue on to the next one.
+                }
+
                 // START OF TYPING
                 channel.startTyping();
 


### PR DESCRIPTION
closes #34 

Events in the sticky should be sorted and grouped by weeks or days. Time remaining should be there also.