### PR TITLE
Fix bugs with nuke

### DIFF
--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -102,7 +102,7 @@ module.exports = {
             try { // For the edge case that happens sometimes for some reason.
                 let selectedMessage = await msg.channel.fetchMessage(arg);
                 selectedMessage.delete();
-            } catch (e) { console.warn(e); } // It's fine.
+            } catch (e) { } // It's fine.
 
             try {
                 module.exports.responses.success.nuked(handleData, messages.size);

--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -48,8 +48,8 @@ module.exports = {
             }
             return 0;
 
-            //* after nuke type
-        } else if (type == "after") { 
+            //* from nuke type
+        } else if (type == "from") { 
             if (!parseInt(arg)) { // If arg is not a number
                 try {
                     await module.exports.responses.error.idIntError(handleData);

--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -105,7 +105,7 @@ module.exports = {
             } catch (e) { console.warn(e); } // It's fine.
 
             try {
-                await setTimeout(async () => { module.exports.responses.success.nuked(handleData, messages.size); }, 5000);
+                module.exports.responses.success.nuked(handleData, messages.size);
             } catch (e) {
                 throw ("Failed to send success message: " + e);
             }

--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -99,6 +99,11 @@ module.exports = {
                 return 3;
             }
 
+            try { // For the edge case that happens sometimes for some reason.
+                let selectedMessage = await msg.channel.fetchMessage(arg);
+                await selectedMessage.delete();
+            }catch(e){} // It's fine.
+
             try {
                 await module.exports.responses.success.nuked(handleData, messages.size);
             } catch (e) {

--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -31,9 +31,10 @@ module.exports = {
                     throw ("Failed to send invalidCount fail message: " + e);
                 }
                 return 2;
-            }
+            } 
 
             try {
+                await msg.delete(); // Delete the OP message also
                 await msg.channel.bulkDelete(arg);
             } catch (e) {
                 console.log(`Failed to delete messages: ${e}`.warn);

--- a/commands/moderation/nuke.js
+++ b/commands/moderation/nuke.js
@@ -11,11 +11,11 @@ module.exports = {
         let msg = handleData.msg;
 
         let type = msg.content.split(" ")[1];
-        let arg = parseInt(msg.content.split(" ")[2]);
+        let arg = msg.content.split(" ")[2];
 
         //* count nuke type
         if (type == "count") {
-            if (!arg) {
+            if (!parseInt(arg)) {
                 try {
                     await module.exports.responses.error.noCount(handleData);
                 } catch (e) {
@@ -49,7 +49,7 @@ module.exports = {
             return 0;
 
             //* from nuke type
-        } else if (type == "from") { 
+        } else if (type == "from") {
             if (!parseInt(arg)) { // If arg is not a number
                 try {
                     await module.exports.responses.error.idIntError(handleData);
@@ -101,11 +101,11 @@ module.exports = {
 
             try { // For the edge case that happens sometimes for some reason.
                 let selectedMessage = await msg.channel.fetchMessage(arg);
-                await selectedMessage.delete();
-            }catch(e){} // It's fine.
+                selectedMessage.delete();
+            } catch (e) { console.warn(e); } // It's fine.
 
             try {
-                await module.exports.responses.success.nuked(handleData, messages.size);
+                await setTimeout(async () => { module.exports.responses.success.nuked(handleData, messages.size); }, 5000);
             } catch (e) {
                 throw ("Failed to send success message: " + e);
             }

--- a/handlers/command/commandData.js
+++ b/handlers/command/commandData.js
@@ -156,11 +156,11 @@ let COMMANDS = [
                 desc: "Deletes a number of messages specified by a number or id",
                 usage: [
                     "count <message count>",
-                    "after <message id>",
+                    "from <message id>",
                 ],
                 examples: [
                     "count 15",
-                    "after 798454351214864"
+                    "from 798454351214864"
                 ],
                 rights: {
                     adminOnly: true


### PR DESCRIPTION
Closes #29 

Fixes nuke with `from (renamed after)` type randomly not deleting the first message due to rounding issue.
Fixes nuke with `count` type counting the command message instead of deleting it individually.